### PR TITLE
Provide access to validator in passed to #validate_code block

### DIFF
--- a/lib/openapi_rspec/helpers.rb
+++ b/lib/openapi_rspec/helpers.rb
@@ -1,9 +1,5 @@
 module OpenapiRspec
   module Helpers
-    def expect_validate_request(code, metadata: {})
-      expect(subject).to validate_request(**request_params(metadata), code: code)
-    end
-
     def request_params(metadata)
       {}.tap do |hash|
         hash[:method] = defined?(http_method) ? http_method : metadata[:method]

--- a/lib/openapi_rspec/module_helpers.rb
+++ b/lib/openapi_rspec/module_helpers.rb
@@ -2,8 +2,9 @@ module OpenapiRspec
   module ModuleHelpers
     def validate_code(code, &block)
       specify do |example|
-        expect_validate_request(code, metadata: example.metadata[:openapi_rspec])
-        instance_eval &block if block_given?
+        validator = RequestValidator.new(**request_params(example.metadata[:openapi_rspec]), code: code)
+        expect(subject).to validator
+        instance_exec validator, &block if block_given?
       end
     end
 

--- a/lib/openapi_rspec/request_validator.rb
+++ b/lib/openapi_rspec/request_validator.rb
@@ -19,7 +19,7 @@ module OpenapiRspec
       @params = params
     end
 
-    attr_reader :method, :path, :code, :media_type, :query, :headers, :params
+    attr_reader :method, :path, :code, :media_type, :query, :headers, :params, :response
 
     def matches?(doc)
       @result = doc.validate_request(path: path, method: method, code: code, media_type: media_type)

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -20,7 +20,10 @@ RSpec.describe "API v1" do
     headers { { "X-Client-Device" => "ios" } }
     query { { tags: ["lucky"] } }
 
-    validate_code(200)
+    validate_code(200) do |validator|
+      result = JSON.parse(validator.response.body)
+      expect(result.first["name"]).to eq("Lucky")
+    end
   end
 
   post "/pets" do


### PR DESCRIPTION
This will allow code like this:

```ruby
 get "/pets" do
    headers { { "X-Client-Device" => "ios" } }
    query { { tags: ["lucky"] } }

    validate_code(200) do |validator|
      result = JSON.parse(validator.response.body)
      expect(result.first["name"]).to eq("Lucky")
    end
  end
```