### PR TITLE
Remove openapi_builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ OpenapiRspec.config.app = Rails.application # or any other Rack app, thanks to r
 Then configure path to your documentation. You can use documentation defined as:
 - static file with `.yaml`/`.yml` or `.json` extension
 - path in your application with `.yaml`/`.yml` or `.json` extension
-- specification splitted with the [Redoc.ly's approach](https://github.com/ReDoc-ly/create-openapi-repo) (also see [openapi_builder](https://github.com/medsolutions/openapi_builder))
 
 ```ruby
 # spec/openapi_helper.rb
@@ -55,9 +54,6 @@ API_V1 = OpenapiRspec.api("./spec/data/openapi.yml")
 
 # application path
 API_V2 = OpenapiRspec.api_by_path("/openapi.json")
-
-# splitted specification
-API_V3 = OpenapiRspec.api("/openapi.json", build: true)
 ```
 
 
@@ -235,7 +231,7 @@ To validate this we will use a small hack:
 
 # ...
 
-API_V1_DOC = OpenapiRspec.api("./openapi/openapi.yml", build: true, api_base_path: "/api/v1")
+API_V1_DOC = OpenapiRspec.api("./openapi/openapi.yml", api_base_path: "/api/v1")
 
 RSpec.configure do |config|
   config.after(:suite) do

--- a/lib/openapi_rspec.rb
+++ b/lib/openapi_rspec.rb
@@ -1,6 +1,5 @@
 require "dry-configurable"
 require "openapi_validator"
-require "openapi_builder"
 require "rspec"
 
 require "openapi_rspec/helpers"
@@ -13,8 +12,7 @@ module OpenapiRspec
 
   setting :app, reader: true
 
-  def self.api(doc, build: false, **params)
-    doc = OpenapiBuilder.call(doc).data if build
+  def self.api(doc, **params)
     OpenapiValidator.call(doc, **params)
   end
 

--- a/openapi_rspec.gemspec
+++ b/openapi_rspec.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4"
 
   spec.add_runtime_dependency "dry-configurable", ">= 0.8"
-  spec.add_runtime_dependency "openapi_builder", ">= 0.1"
   spec.add_runtime_dependency "openapi_validator", ">= 0.3"
   spec.add_runtime_dependency "rack-test", "~> 1.1"
   spec.add_runtime_dependency "rspec", "~> 3.0"

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -5,7 +5,7 @@ OpenapiRspec.config.app = HelloWorldApp.new
 
 RSpec.describe "API v1" do
   # do not forget additional_schemas
-  subject { OpenapiRspec.api("./spec/data/openapi.yml", build: false, api_base_path: "/v1") }
+  subject { OpenapiRspec.api("./spec/data/openapi.yml", api_base_path: "/v1") }
 
   it "is valid openapi spec" do
     expect(subject).to validate_documentation


### PR DESCRIPTION
`openapi_builder` is an unnecessary dependency. Instead of using `OpenapiRspec.api('/openapi.json', build: true)` one can build spec explicitly:

```ruby
require 'openapi_builder'

OpenapiRspec.api(OpenapiBuilder.call('/openapi.json').data)
```