### PR TITLE
Add support for setting a request body aka rack input

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ To validate response use:
 # ...
 ```
 
-To set **request body** use `params` helper method:
+To set **request body** (as form data) use `params` helper method and provide a `Hash`:
 
 ```ruby
 # ...
@@ -159,6 +159,19 @@ To set **request body** use `params` helper method:
   end
 # ...
 ```
+
+To set **raw request body** use the `params` helper method and provide a `String`:
+
+```ruby
+# ...
+  post "/pets" do
+    params { JSON.dump(name: "Lucky") }
+
+    validate_code(201)
+  end
+# ...
+```
+
 
 To set **path parameter** use `let` helper method:
 

--- a/lib/openapi_rspec/helpers.rb
+++ b/lib/openapi_rspec/helpers.rb
@@ -5,10 +5,16 @@ module OpenapiRspec
     def request_params(metadata)
       path = defined?(uri) ? uri : metadata[:uri]
       method = defined?(http_method) ? http_method : metadata[:method]
+      params = if openapi_rspec_params.is_a?(Hash)
+        path_params(path).merge!(openapi_rspec_params)
+      else
+        openapi_rspec_params
+      end
+
       {
         method: method,
         path: path,
-        params: path_params(path).merge!(openapi_rspec_params),
+        params: params,
         headers: openapi_rspec_headers,
         query: openapi_rspec_query,
         media_type: openapi_rspec_media_type,

--- a/spec/example_by_path_spec.rb
+++ b/spec/example_by_path_spec.rb
@@ -20,4 +20,16 @@ RSpec.describe "API v1 (by path)" do
       expect(result.first["name"]).to eq("Lucky")
     end
   end
+
+  post "/pets" do
+    headers do
+      { 'CONTENT_TYPE' => 'application/json' }
+    end
+
+    params do
+      JSON.dump(name: "Lucky")
+    end
+
+    validate_code(200)
+  end
 end

--- a/spec/support/hello_world_app.rb
+++ b/spec/support/hello_world_app.rb
@@ -6,7 +6,23 @@ class HelloWorldApp
     when "/openapi.yml"
       [200, {}, [File.read("./spec/data/openapi.yml")]]
     when /pets.*/
-      [200, {"Content-Type" => "application/json"}, ['[{"id": 23, "name": "Lucky"}]']]
+      case env["REQUEST_METHOD"]
+      when "GET"
+        [200, {"Content-Type" => "application/json"}, ['[{"id": 23, "name": "Lucky"}]']]
+      when "POST"
+        request = Rack::Request.new(env)
+
+        data = if request.form_data?
+          request.params
+        else
+          JSON.parse(request.body.string)
+        end
+
+        lucky = data["id"] = 23
+        [200, {"Content-Type" => "application/json"}, [JSON.dump(lucky)]]
+      else
+        [405, {}, []]
+      end
     when "/bad.yaml"
       [200, {}, [":"]]
     when "/no_content"


### PR DESCRIPTION
This allows for setting the request body directly. Which is useful for providing JSON documents with POST requests for example.